### PR TITLE
Provide option to use ssh agent, if used privateKey and/or passphrase is not required

### DIFF
--- a/config/config.ts.dist
+++ b/config/config.ts.dist
@@ -15,7 +15,6 @@ export const config = {
         host: 'gerrit.yourdomain.com',
         username: 'your.gerrit.username',
         port: 29418
-        // passphrase: '****'; optional additional key to include if private key is encrypted
     }, //gerrit server configuration
     me: 'your.name@google.com', //your gerrit email
     team: [
@@ -26,7 +25,11 @@ export const config = {
     icon: {
         'team.member1@google.com': 'crying.png'
     }, //'email' to 'image file name' path map
-    privateKey: '/Users/me/.ssh/id_rsa', //path to your privateKey (required by SSH to set connection)
+    ssh: {
+        useAgent: true, // set this to false if providing privateKey and/or passphrase
+        // privateKey: '/Users/me/.ssh/id_rsa' // path to your privateKey (required by SSH to set connection)
+        // passphrase: '****' // optional additional key to include if private key is encrypted
+    }
     projects: [
         'project name'
     ]

--- a/src/streams/ssh-stream.ts
+++ b/src/streams/ssh-stream.ts
@@ -26,9 +26,10 @@ const connectionConfig = {
     host,
     port,
     username,
-    privateKey: fs.readFileSync(config.privateKey),
-    passphrase: 'passphrase' in config.gerrit ? config.gerrit['passphrase'] : null,
-    keepaliveInterval: config.keepaliveInterval || 1000
+    privateKey: config.ssh.useAgent? null: fs.readFileSync((config.ssh as any).privateKey),
+    passphrase: 'passphrase' in config.ssh ? config.ssh['passphrase'] : null,
+    keepaliveInterval: config.keepaliveInterval || 1000,
+    agent: config.ssh.useAgent? process.env.SSH_AUTH_SOCK: null
 };
 
 function initialize() {


### PR DESCRIPTION
Was having issues connecting with ssh2, see similar issue: https://github.com/mscdex/ssh2/issues/598

Allowing user to use ssh agent is a good workaround