### PR TITLE
Jenkins and jira truly optional

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,8 +1,8 @@
-import { config } from '../config/config';
+import {config} from '../config/config';
 import * as _ from 'underscore';
-import { GerritAccount, GerritChange, GerritApproval } from './interfaces/gerrit-event';
+import {GerritAccount, GerritChange, GerritApproval} from './interfaces/gerrit-event';
 
-const JENKINS_FAILED_BUILD_REGEXP = config.jenkins+'(.+)\\s:\\sFAILURE';
+const JENKINS_FAILED_BUILD_REGEXP = (config as any).jenkins + '(.+)\\s:\\sFAILURE';
 const trackedChanges = {};
 
 export function isChangeTracked(change: GerritChange) {
@@ -17,33 +17,34 @@ export function trackChange(change: GerritChange) {
     trackedChanges[change.id] = true;
 }
 
-export function isTeamMember(account: GerritAccount){
+export function isTeamMember(account: GerritAccount) {
     return config.team.indexOf(account.email) > -1;
 }
 
-export function isNotTeamMember(account: GerritAccount){
+export function isNotTeamMember(account: GerritAccount) {
     return !isTeamMember(account);
 }
 
-export function isGerritAdmin(account: GerritAccount){
+export function isGerritAdmin(account: GerritAccount) {
     return account.name === 'Gerrit Admin';
 }
 
-export function isProjectAllowed(change: GerritChange){
+export function isProjectAllowed(change: GerritChange) {
     return config.projects.indexOf(change.project) > -1;
 }
 
-export function isProjectNotAllowed(change: GerritChange){
+export function isProjectNotAllowed(change: GerritChange) {
     return !isProjectAllowed(change);
 }
 
-export function isMe(account: GerritAccount){
+export function isMe(account: GerritAccount) {
     return account.email === config.me;
 }
 
-export function isNotMe(account: GerritAccount){
+export function isNotMe(account: GerritAccount) {
     return !isMe(account);
 }
+
 //----------------------------------
 export function parseComment(comment: string) {
     comment = (comment || '');
@@ -54,21 +55,22 @@ export function parseComment(comment: string) {
 }
 
 export function formatApprovals(approvals: GerritApproval[]) {
-    if(approvals){
+    if (approvals) {
         return approvals.map((approval) => {
-            var value = (+approval.value > 0) ? ('+'+approval.value) : approval.value;
+            var value = (+approval.value > 0) ? ('+' + approval.value) : approval.value;
             return approval.description + value;
         }).join(', ');
-    }else{
+    } else {
         return '';
     }
 }
 
 export function generateFailedBuildJenkinsUrl(comment: string) {
-    if(comment && config.jenkins){
+    let jenkins = (config as any).jenkins;
+    if (comment && jenkins) {
         let result = comment.match(new RegExp(JENKINS_FAILED_BUILD_REGEXP));
-        if(result && result[1]){
-            return [config.jenkins, result[1]].join('');
+        if (result && result[1]) {
+            return [jenkins, result[1]].join('');
         }
     }
 }

--- a/src/jira/jira.ts
+++ b/src/jira/jira.ts
@@ -83,4 +83,4 @@ class Jira {
     }
 }
 
-export const avatars = new Jira(config.jira).getAvatars();
+export const avatars = "jira" in config ? new Jira((config as any).jira).getAvatars() : [];


### PR DESCRIPTION
If the user does not provide ```jira``` or ```jenkins``` options, then ```npm start``` fails. With this change, these two options are *truly* optional.