### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:10
+
+ENV HOME=/gerrit-native-notifications
+
+WORKDIR $HOME
+
+COPY . $HOME
+
+RUN npm install
+
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ Whenever we receive event, with type `ref-updated`, we will ignore it.
 $ npm start
 ```
 
+## Run with docker
+
+```bash
+docker build -t <image> .
+docker run --rm -it -v ~/.ssh:/root/.ssh:ro -v /gerrit-native-notifications/stream:/gerrit-native-notifications/stream <image>
+```
+
+The matched gerrit events will be available in the ```stream``` file. By containerizing gerrit-native-notifications, complex pipelines can be created with multiple streams as the source.
+
 ## Test your gerrit events stream via CLI
 ```
 $ ssh -p 29418 your-username@gerrit-host gerrit stream-events


### PR DESCRIPTION
#10 provides an interesting proposal. I could imagine using this project as a means to aggregate multiple streams as a source to a metrics pipeline. 

```
stream-1 -> file1 
                   -> job to record various metrics -> post to dashboard
stream-2 -> file2
```

This pull request provides a simple Dockerfile which can be run like so:

```bash
docker build -t <image> .
docker run --rm -it -v ~/.ssh:/root/.ssh:ro -v /gerrit-native-notifications/stream:/gerrit-native-notifications/stream <image>
```

Since the project already writes notifications to file ```stream```, should be straightforward to read the file and hook into any pipeline.